### PR TITLE
Catch unhandled ObjectDisposedException

### DIFF
--- a/Mono.Nat/Pmp/PmpNatDevice.cs
+++ b/Mono.Nat/Pmp/PmpNatDevice.cs
@@ -250,6 +250,11 @@ namespace Mono.Nat.Pmp
                     state.Success = false;
                     return;
                 }
+                catch (ObjectDisposedException)
+                {
+                    state.Success = false;
+                    return;
+                }
 			
 				if (data.Length < 16)
 					continue;


### PR DESCRIPTION
We are seeing this in our application:

https://github.com/MediaBrowser/MediaBrowser/blob/master/MediaBrowser.Server.Implementations/EntryPoints/ExternalPortForwarding.cs

2014-05-23 16:06:15.7753 Error - Main: UnhandledException
    Cannot access a disposed object.
    Object name: 'System.Net.Sockets.UdpClient'.
    System.ObjectDisposedException
       at System.Net.Sockets.UdpClient.Receive(IPEndPoint& remoteEP)
       at Mono.Nat.Pmp.PmpNatDevice.CreatePortMapListen(Object obj)
       at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(Object state)
       at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
       at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
       at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
       at System.Threading.ThreadPoolWorkQueue.Dispatch()
       at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
