### PR TITLE
Allow protocols to be configurable

### DIFF
--- a/Mono.Nat/ISearcher.cs
+++ b/Mono.Nat/ISearcher.cs
@@ -46,5 +46,6 @@ namespace Mono.Nat
         void Search();
         void Handle(IPAddress localAddress, byte[] response, IPEndPoint endpoint);
         DateTime NextSearch { get; }
+        NatProtocol Protocol { get; }
     }
 }

--- a/Mono.Nat/Mono.Nat.csproj
+++ b/Mono.Nat/Mono.Nat.csproj
@@ -72,6 +72,7 @@
     <Compile Include="INatDevice.cs" />
     <Compile Include="ISearcher.cs" />
     <Compile Include="Mapping.cs" />
+    <Compile Include="NatProtocol.cs" />
     <Compile Include="NatUtility.cs" />
     <Compile Include="Pmp\Mappers\PmpMapper.cs" />
     <Compile Include="Pmp\Pmp.cs" />

--- a/Mono.Nat/NatProtocol.cs
+++ b/Mono.Nat/NatProtocol.cs
@@ -1,0 +1,9 @@
+﻿
+namespace Mono.Nat
+{
+    public enum NatProtocol
+    {
+        Upnp = 0,
+        Pmp = 1
+    }
+}

--- a/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
+++ b/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
@@ -140,5 +140,10 @@ namespace Mono.Nat
             if (DeviceFound != null)
                 DeviceFound(this, args);
         }
+
+        public NatProtocol Protocol
+        {
+            get { return NatProtocol.Pmp; }
+        }
     }
 }

--- a/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
+++ b/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
@@ -224,5 +224,10 @@ namespace Mono.Nat
             if (DeviceFound != null)
                 DeviceFound(this, args);
         }
+
+        public NatProtocol Protocol
+        {
+            get { return NatProtocol.Upnp; }
+        }
     }
 }


### PR DESCRIPTION
By allowing the search protocols to be configurable, applications that are already searching for Upnp devices can avoid the expense of two simultaneous search loops. A public Handle method is then exposed on NatUtility to allow the library to handle messages received externally.

We plan to use this in Emby Server:

https://github.com/MediaBrowser/MediaBrowser
